### PR TITLE
il- add javascript fixtures for MenuItemReview table

### DIFF
--- a/frontend/src/fixtures/menuItemReviewFixtures.js
+++ b/frontend/src/fixtures/menuItemReviewFixtures.js
@@ -1,0 +1,39 @@
+const menuItemReviewFixtures = {
+    oneMenuItemReview: {
+      "id": 1,
+      "itemId": 27,
+      "reviewerEmail": "cgaucho@ucsb.edu",
+      "stars": 3,
+      "dateReviewed": "2022-04-20T00:00:00",
+      "comments": "bland af but edible I guess"
+    },
+    threeMenuItemReviews: [
+      {
+        "id": 1,
+        "itemId": 27,
+        "reviewerEmail": "cgaucho@ucsb.edu",
+        "stars": 3,
+        "dateReviewed": "2022-04-20T00:00:00",
+        "comments": "bland af but edible I guess"
+      },
+                    {
+        "id": 2,
+        "itemId": 29,
+        "reviewerEmail": "cgaucho@ucsb.edu",
+        "stars": 5,
+        "dateReviewed": "2022-04-20T00:00:00",
+        "comments": "best veggie pizza ever"
+      },
+      {
+        "id": 3,
+        "itemId": 29,
+        "reviewerEmail": "ldelplaya@ucsb.edu",
+        "stars": 0,
+        "dateReviewed": "2022-04-21T00:00:00",
+        "comments": "not tryna get food poisoning, but if I were this would do it"
+      }
+    ]
+  };
+  
+  export { menuItemReviewFixtures };
+  

--- a/frontend/src/fixtures/menuItemReviewFixtures.js
+++ b/frontend/src/fixtures/menuItemReviewFixtures.js
@@ -1,37 +1,9 @@
 const menuItemReviewFixtures = {
     oneMenuItemReview: {
-      "id": 1,
-      "itemId": 27,
-      "reviewerEmail": "cgaucho@ucsb.edu",
-      "stars": 3,
-      "dateReviewed": "2022-04-20T00:00:00",
-      "comments": "bland af but edible I guess"
+      
     },
     threeMenuItemReviews: [
-      {
-        "id": 1,
-        "itemId": 27,
-        "reviewerEmail": "cgaucho@ucsb.edu",
-        "stars": 3,
-        "dateReviewed": "2022-04-20T00:00:00",
-        "comments": "bland af but edible I guess"
-      },
-                    {
-        "id": 2,
-        "itemId": 29,
-        "reviewerEmail": "cgaucho@ucsb.edu",
-        "stars": 5,
-        "dateReviewed": "2022-04-20T00:00:00",
-        "comments": "best veggie pizza ever"
-      },
-      {
-        "id": 3,
-        "itemId": 29,
-        "reviewerEmail": "ldelplaya@ucsb.edu",
-        "stars": 0,
-        "dateReviewed": "2022-04-21T00:00:00",
-        "comments": "not tryna get food poisoning, but if I were this would do it"
-      }
+
     ]
   };
   

--- a/frontend/src/fixtures/menuItemReviewFixtures.js
+++ b/frontend/src/fixtures/menuItemReviewFixtures.js
@@ -1,11 +1,38 @@
 const menuItemReviewFixtures = {
-    oneMenuItemReview: {
-      
+  oneMenuItemReview: {
+    id: 1,
+    itemId: 27,
+    reviewerEmail: "cgaucho@ucsb.edu",
+    stars: 3,
+    dateReviewed: "2022-04-20T00:00:00",
+    comments: "bland af but edible I guess",
+  },
+  threeMenuItemReviews: [
+    {
+      id: 1,
+      itemId: 27,
+      reviewerEmail: "cgaucho@ucsb.edu",
+      stars: 3,
+      dateReviewed: "2022-04-20T00:00:00",
+      comments: "bland af but edible I guess",
     },
-    threeMenuItemReviews: [
+    {
+      id: 2,
+      itemId: 29,
+      reviewerEmail: "cgaucho@ucsb.edu",
+      stars: 5,
+      dateReviewed: "2022-04-20T00:00:00",
+      comments: "best veggie pizza ever",
+    },
+    {
+      id: 3,
+      itemId: 29,
+      reviewerEmail: "ldelplaya@ucsb.edu",
+      stars: 0,
+      dateReviewed: "2022-04-21T00:00:00",
+      comments: "not tryna get food poisoning, but if I were this would do it",
+    },
+  ],
+};
 
-    ]
-  };
-  
-  export { menuItemReviewFixtures };
-  
+export { menuItemReviewFixtures };

--- a/src/main/java/edu/ucsb/cs156/example/controllers/MenuItemReviewController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/MenuItemReviewController.java
@@ -65,6 +65,7 @@ public class MenuItemReviewController extends ApiController {
     @PreAuthorize("hasRole('ROLE_ADMIN')")
     @PostMapping("/post")
     public MenuItemReview postMenuItemReview(
+            @Parameter(name="itemId") @RequestParam long itemId,
             @Parameter(name="reviewerEmail") @RequestParam String reviewerEmail,
             @Parameter(name="stars") @RequestParam int stars,
             @Parameter(name="dateReviewed", description="date (in iso format, e.g. YYYY-mm-ddTHH:MM:SS; see https://en.wikipedia.org/wiki/ISO_8601)") @RequestParam("dateReviewed") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime dateReviewed,
@@ -77,6 +78,7 @@ public class MenuItemReviewController extends ApiController {
         log.info("localDateTime={}", dateReviewed);
 
         MenuItemReview menuItemReview = new MenuItemReview();
+        menuItemReview.setItemId(itemId);
         menuItemReview.setComments(comments);
         menuItemReview.setDateReviewed(dateReviewed);
         menuItemReview.setReviewerEmail(reviewerEmail);
@@ -121,6 +123,7 @@ public class MenuItemReviewController extends ApiController {
         MenuItemReview menuItemReview = menuItemReviewRepository.findById(id)
                 .orElseThrow(() -> new EntityNotFoundException(MenuItemReview.class, id));
 
+        menuItemReview.setItemId(incoming.getItemId());
         menuItemReview.setComments(incoming.getComments());
         menuItemReview.setDateReviewed(incoming.getDateReviewed());
         menuItemReview.setReviewerEmail(incoming.getReviewerEmail());

--- a/src/test/java/edu/ucsb/cs156/example/controllers/MenuItemReviewControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/MenuItemReviewControllerTests.java
@@ -84,6 +84,7 @@ public class MenuItemReviewControllerTests extends ControllerTestCase {
                 LocalDateTime ldt1 = LocalDateTime.parse("2022-01-03T00:00:00");
 
                 MenuItemReview menuItemReview1 = MenuItemReview.builder()
+                    .itemId(1)
                     .reviewerEmail("null")
                     .stars(1)
                     .dateReviewed(ldt1)
@@ -116,6 +117,7 @@ public class MenuItemReviewControllerTests extends ControllerTestCase {
                 LocalDateTime ldt1 = LocalDateTime.parse("2022-01-03T00:00:00");
 
                 MenuItemReview menuItemReview1 = MenuItemReview.builder()
+                    .itemId(1)
                     .reviewerEmail("null")
                     .stars(1)
                     .dateReviewed(ldt1)
@@ -126,7 +128,7 @@ public class MenuItemReviewControllerTests extends ControllerTestCase {
 
                 // act
                 MvcResult response = mockMvc.perform(
-                                post("/api/menuitemreview/post?reviewerEmail=null&stars=1&dateReviewed=2022-01-03T00:00:00&comments=ldt1")
+                                post("/api/menuitemreview/post?itemId=1&reviewerEmail=null&stars=1&dateReviewed=2022-01-03T00:00:00&comments=ldt1")
                                                 .with(csrf()))
                                 .andExpect(status().isOk()).andReturn();
 
@@ -153,6 +155,7 @@ public class MenuItemReviewControllerTests extends ControllerTestCase {
                 LocalDateTime ldt1 = LocalDateTime.parse("2022-01-03T00:00:00");
 
                 MenuItemReview menuItemReview1 = MenuItemReview.builder()
+                    .itemId(1)
                     .reviewerEmail("null")
                     .stars(1)
                     .dateReviewed(ldt1)
@@ -204,6 +207,7 @@ public class MenuItemReviewControllerTests extends ControllerTestCase {
                 LocalDateTime ldt2 = LocalDateTime.parse("2023-01-03T00:00:00");
 
                 MenuItemReview menuItemReview1 = MenuItemReview.builder()
+                    .itemId(1)
                     .reviewerEmail("null")
                     .stars(1)
                     .dateReviewed(ldt1)
@@ -211,6 +215,7 @@ public class MenuItemReviewControllerTests extends ControllerTestCase {
                     .build();
 
                 MenuItemReview editedMenuItemReview = MenuItemReview.builder()
+                    .itemId(1)
                     .reviewerEmail("null2")
                     .stars(4)
                     .dateReviewed(ldt2)
@@ -246,6 +251,7 @@ public class MenuItemReviewControllerTests extends ControllerTestCase {
                 LocalDateTime ldt1 = LocalDateTime.parse("2022-01-03T00:00:00");
 
                 MenuItemReview menuItemReview1 = MenuItemReview.builder()
+                    .itemId(1)
                     .reviewerEmail("null")
                     .stars(1)
                     .dateReviewed(ldt1)
@@ -280,6 +286,7 @@ public class MenuItemReviewControllerTests extends ControllerTestCase {
                 LocalDateTime ldt1 = LocalDateTime.parse("2022-01-03T00:00:00");
 
                 MenuItemReview menuItemReview1 = MenuItemReview.builder()
+                    .itemId(1)
                     .reviewerEmail("null")
                     .stars(1)
                     .dateReviewed(ldt1)


### PR DESCRIPTION
Closes #36 

Merge AFTER PR #65 (this branch is based on that branch).

In this PR, we add fixtures for the MenuItemReview table in the frontend code.

These will be used for tests and for storybook entries later on.