### PR TITLE
xw - added UCSBDiningCommonsMenuItems fixtures

### DIFF
--- a/frontend/src/fixtures/ucsbDiningCommonsMenuItemFixtures.js
+++ b/frontend/src/fixtures/ucsbDiningCommonsMenuItemFixtures.js
@@ -1,0 +1,30 @@
+const ucsbDiningCommonsMenuItemFixtures = {
+  oneUCSBDiningCommonsMenuItem: {
+    id: 1,
+    diningCommonsCode: "ortega",
+    name: "banana",
+    station: "fruits",
+  },
+  threeUCSBDiningCommonsMenuItem: [
+    {
+      id: 1,
+      diningCommonsCode: "ortega",
+      name: "banana",
+      station: "fruits",
+    },
+    {
+      id: 2,
+      diningCommonsCode: "portola",
+      name: "pasta",
+      station: "deli",
+    },
+    {
+      id: 3,
+      diningCommonsCode: "carillo",
+      name: "yogurt",
+      station: "salad bar",
+    },
+  ],
+};
+
+export { ucsbDiningCommonsMenuItemFixtures };


### PR DESCRIPTION
Closes #9 

In this PR, we add fixtures for the UCSBDiningCommonsMenuItem table in the frontend code.

These will be used for tests and for storybook entries later on.