### PR TITLE
xw - ucsb dining commons menu items edit page

### DIFF
--- a/frontend/src/main/components/UCSBDiningCommonsMenuItems/UCSBDiningCommonsMenuItemTable.js
+++ b/frontend/src/main/components/UCSBDiningCommonsMenuItems/UCSBDiningCommonsMenuItemTable.js
@@ -17,7 +17,7 @@ export default function UCSBDiningCommonsMenuItemTable({
   const navigate = useNavigate();
 
   const editCallback = (cell) => {
-    navigate(`/UCSBDiningCommonsMenuItems/edit/${cell.row.values.id}`);
+    navigate(`/diningcommonsmenuitem/edit/${cell.row.values.id}`);
   };
 
   // Stryker disable all : hard to test for query caching

--- a/frontend/src/main/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemEditPage.js
+++ b/frontend/src/main/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemEditPage.js
@@ -1,11 +1,79 @@
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import { useParams } from "react-router-dom";
+import UCSBDiningCommonsMenuItemForm from "main/components/UCSBDiningCommonsMenuItems/UCSBDiningCommonsMenuItemForm";
+import { Navigate } from "react-router-dom";
+import { useBackend, useBackendMutation } from "main/utils/useBackend";
+import { toast } from "react-toastify";
 
-export default function UCSBDiningCommonsMenuItemEditPage() {
-  // Stryker disable all : placeholder for future implementation
+export default function UCSBDiningCommonsMenuItemEditPage({
+  storybook = false,
+}) {
+  let { id } = useParams();
+
+  const {
+    data: UCSBDiningCommonsMenuItems,
+    _error,
+    _status,
+  } = useBackend(
+    // Stryker disable next-line all : don't test internal caching of React Query
+    [`/api/ucsbdiningcommonsmenuitems?id=${id}`],
+    {
+      // Stryker disable next-line all : GET is the default, so mutating this to "" doesn't introduce a bug
+      method: "GET",
+      url: `/api/ucsbdiningcommonsmenuitems`,
+      params: {
+        id,
+      },
+    },
+  );
+
+  const objectToAxiosPutParams = (UCSBDiningCommonsMenuItems) => ({
+    url: "/api/ucsbdiningcommonsmenuitems",
+    method: "PUT",
+    params: {
+      id: UCSBDiningCommonsMenuItems.id,
+    },
+    data: {
+      diningCommonsCode: UCSBDiningCommonsMenuItems.diningCommonsCode,
+      name: UCSBDiningCommonsMenuItems.name,
+      station: UCSBDiningCommonsMenuItems.station,
+    },
+  });
+
+  const onSuccess = (UCSBDiningCommonsMenuItems) => {
+    toast(
+      `UCSBDiningCommonsMenuItems Updated - id: ${UCSBDiningCommonsMenuItems.id} name: ${UCSBDiningCommonsMenuItems.name}`,
+    );
+  };
+
+  const mutation = useBackendMutation(
+    objectToAxiosPutParams,
+    { onSuccess },
+    // Stryker disable next-line all : hard to set up test for caching
+    [`/api/ucsbdiningcommonsmenuitems?id=${id}`],
+  );
+
+  const { isSuccess } = mutation;
+
+  const onSubmit = async (data) => {
+    mutation.mutate(data);
+  };
+
+  if (isSuccess && !storybook) {
+    return <Navigate to="/diningcommonsmenuitem" />;
+  }
+
   return (
     <BasicLayout>
       <div className="pt-2">
-        <h1>Edit page not yet implemented</h1>
+        <h1>Edit UCSB Dining Commons Menu Item</h1>
+        {UCSBDiningCommonsMenuItems && (
+          <UCSBDiningCommonsMenuItemForm
+            submitAction={onSubmit}
+            buttonLabel={"Update"}
+            initialContents={UCSBDiningCommonsMenuItems}
+          />
+        )}
       </div>
     </BasicLayout>
   );

--- a/frontend/src/stories/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemEditPage.stories.js
+++ b/frontend/src/stories/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemEditPage.stories.js
@@ -1,0 +1,49 @@
+import React from "react";
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import { http, HttpResponse } from "msw";
+
+import UCSBDiningCommonsMenuItemEditPage from "main/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemEditPage";
+import { ucsbDiningCommonsMenuItemFixtures } from "fixtures/ucsbDiningCommonsMenuItemFixtures";
+
+export default {
+  title: "pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemEditPage",
+  component: UCSBDiningCommonsMenuItemEditPage,
+};
+
+const Template = () => <UCSBDiningCommonsMenuItemEditPage storybook={true} />;
+
+export const Default = Template.bind({});
+Default.parameters = {
+  msw: [
+    http.get("/api/currentUser", () => {
+      return HttpResponse.json(apiCurrentUserFixtures.userOnly, {
+        status: 200,
+      });
+    }),
+    http.get("/api/systemInfo", () => {
+      return HttpResponse.json(systemInfoFixtures.showingNeither, {
+        status: 200,
+      });
+    }),
+    http.get("/api/ucsbdiningcommonsmenuitems", () => {
+      return HttpResponse.json(
+        ucsbDiningCommonsMenuItemFixtures.threeUCSBDiningCommonsMenuItem[0],
+        {
+          status: 200,
+        },
+      );
+    }),
+    http.put("/api/ucsbdiningcommonsmenuitems", () => {
+      return HttpResponse.json(
+        {
+          id: 17,
+          diningCommonsCode: "Portola",
+          name: "Banana pie",
+          station: "Desserts",
+        },
+        { status: 200 },
+      );
+    }),
+  ],
+};

--- a/frontend/src/tests/components/UCSBDiningCommonsMenuItems/UCSBDiningCommonsMenuItemTable.test.js
+++ b/frontend/src/tests/components/UCSBDiningCommonsMenuItems/UCSBDiningCommonsMenuItemTable.test.js
@@ -188,7 +188,7 @@ describe("UCSBDiningCommonsMenuItemTable tests", () => {
     // assert - check that the navigate function was called with the expected path
     await waitFor(() =>
       expect(mockedNavigate).toHaveBeenCalledWith(
-        "/UCSBDiningCommonsMenuItems/edit/1",
+        "/diningcommonsmenuitem/edit/1",
       ),
     );
   });

--- a/frontend/src/tests/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemEditPage.test.js
+++ b/frontend/src/tests/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemEditPage.test.js
@@ -1,43 +1,170 @@
-import { render, screen } from "@testing-library/react";
-import UCSBDiningCommonsMenuItemEditPage from "main/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemEditPage";
+import { fireEvent, render, waitFor, screen } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
+import UCSBDiningCommonsMenuItemEditPage from "main/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemEditPage";
 
 import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
+import mockConsole from "jest-mock-console";
+
+const mockToast = jest.fn();
+jest.mock("react-toastify", () => {
+  const originalModule = jest.requireActual("react-toastify");
+  return {
+    __esModule: true,
+    ...originalModule,
+    toast: (x) => mockToast(x),
+  };
+});
+
+const mockNavigate = jest.fn();
+jest.mock("react-router-dom", () => {
+  const originalModule = jest.requireActual("react-router-dom");
+  return {
+    __esModule: true,
+    ...originalModule,
+    useParams: () => ({
+      id: 17,
+    }),
+    Navigate: (x) => {
+      mockNavigate(x);
+      return null;
+    },
+  };
+});
 
 describe("UCSBDiningCommonsMenuItemEditPage tests", () => {
-  const axiosMock = new AxiosMockAdapter(axios);
+  describe("when the backend doesn't return data", () => {
+    const axiosMock = new AxiosMockAdapter(axios);
 
-  const setupUserOnly = () => {
-    axiosMock.reset();
-    axiosMock.resetHistory();
-    axiosMock
-      .onGet("/api/currentUser")
-      .reply(200, apiCurrentUserFixtures.userOnly);
-    axiosMock
-      .onGet("/api/systemInfo")
-      .reply(200, systemInfoFixtures.showingNeither);
-  };
+    beforeEach(() => {
+      axiosMock.reset();
+      axiosMock.resetHistory();
+      axiosMock
+        .onGet("/api/currentUser")
+        .reply(200, apiCurrentUserFixtures.userOnly);
+      axiosMock
+        .onGet("/api/systemInfo")
+        .reply(200, systemInfoFixtures.showingNeither);
+      axiosMock
+        .onGet("/api/ucsbdiningcommonsmenuitems", { params: { id: 17 } })
+        .timeout();
+    });
 
-  const queryClient = new QueryClient();
-  test("Renders expected content", async () => {
-    // arrange
+    const queryClient = new QueryClient();
+    test("renders header but form is not present", async () => {
+      const restoreConsole = mockConsole();
 
-    setupUserOnly();
+      render(
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter>
+            <UCSBDiningCommonsMenuItemEditPage />
+          </MemoryRouter>
+        </QueryClientProvider>,
+      );
+      await screen.findByText("Edit UCSB Dining Commons Menu Item");
+      expect(
+        screen.queryByTestId("UCSBDiningCommonsMenuItem-name"),
+      ).not.toBeInTheDocument();
+      restoreConsole();
+    });
+  });
 
-    // act
-    render(
-      <QueryClientProvider client={queryClient}>
-        <MemoryRouter>
-          <UCSBDiningCommonsMenuItemEditPage />
-        </MemoryRouter>
-      </QueryClientProvider>,
-    );
+  describe("tests where backend is working normally", () => {
+    const axiosMock = new AxiosMockAdapter(axios);
 
-    // assert
-    await screen.findByText("Edit page not yet implemented");
+    beforeEach(() => {
+      axiosMock.reset();
+      axiosMock.resetHistory();
+      axiosMock
+        .onGet("/api/currentUser")
+        .reply(200, apiCurrentUserFixtures.userOnly);
+      axiosMock
+        .onGet("/api/systemInfo")
+        .reply(200, systemInfoFixtures.showingNeither);
+      axiosMock
+        .onGet("/api/ucsbdiningcommonsmenuitems", { params: { id: 17 } })
+        .reply(200, {
+          id: 17,
+          diningCommonsCode: "Portola",
+          name: "Salad",
+          station: "Salad Bar",
+        });
+      axiosMock.onPut("/api/ucsbdiningcommonsmenuitems").reply(200, {
+        id: 17,
+        diningCommonsCode: "Portola",
+        name: "Banana pie",
+        station: "Desserts",
+      });
+    });
+
+    const queryClient = new QueryClient();
+
+    test("Is populated with the data provided, and changes when data is changed", async () => {
+      render(
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter>
+            <UCSBDiningCommonsMenuItemEditPage />
+          </MemoryRouter>
+        </QueryClientProvider>,
+      );
+
+      await screen.findByTestId("UCSBDiningCommonsMenuItemForm-id");
+
+      const idField = screen.getByTestId("UCSBDiningCommonsMenuItemForm-id");
+      const diningCommonsCodeField = screen.getByTestId(
+        "UCSBDiningCommonsMenuItemForm-diningCommonsCode",
+      );
+      const nameField = screen.getByLabelText("Name");
+      const stationField = screen.getByLabelText("Station");
+      const submitButton = screen.getByText("Update");
+
+      expect(idField).toBeInTheDocument();
+      expect(idField).toHaveValue("17");
+
+      expect(diningCommonsCodeField).toBeInTheDocument();
+      expect(diningCommonsCodeField).toHaveValue("Portola");
+      expect(nameField).toBeInTheDocument();
+      expect(nameField).toHaveValue("Salad");
+      expect(stationField).toBeInTheDocument();
+      expect(stationField).toHaveValue("Salad Bar");
+
+      expect(submitButton).toHaveTextContent("Update");
+
+      fireEvent.change(diningCommonsCodeField, {
+        target: { value: "Portola" },
+      });
+      fireEvent.change(nameField, {
+        target: { value: "Banana pie" },
+      });
+      fireEvent.change(stationField, {
+        target: { value: "Desserts" },
+      });
+      fireEvent.click(submitButton);
+
+      await waitFor(() => expect(mockToast).toHaveBeenCalled());
+      expect(mockToast).toHaveBeenCalledWith(
+        "UCSBDiningCommonsMenuItems Updated - id: 17 name: Banana pie",
+      );
+
+      expect(mockNavigate).toHaveBeenCalledWith({
+        to: "/diningcommonsmenuitem",
+      });
+
+      expect(axiosMock.history.put.length).toBe(1); // times called
+      expect(axiosMock.history.put[0].params).toEqual({ id: 17 });
+      expect(axiosMock.history.put[0].data).toBe(
+        JSON.stringify({
+          diningCommonsCode: "Portola",
+          name: "Banana pie",
+          station: "Desserts",
+        }),
+      ); // posted object
+      expect(mockNavigate).toHaveBeenCalledWith({
+        to: "/diningcommonsmenuitem",
+      });
+    });
   });
 });


### PR DESCRIPTION
Closes #15 

Merge after #78 , #81 , #82 

In this PR, we replace the UCSBDiningCommonsMenuItem Edit page with a working Edit page.

To test:
1. Visit the dokku deployment at https://team02-xanxp-dev.dokku-03.cs.ucsb.edu
2. Login
3. Navigate to the UCSBDiningCommonsMenuItem page. If there isn't a menu item listed yet, create one.
4. Click the edit button
5. Make changes to each of the fields and click Update
6. See that your changes took effect

<img width="1439" alt="Screenshot 2025-05-03 at 6 48 30 AM" src="https://github.com/user-attachments/assets/fd08d4c2-2622-4dd2-a2fe-215b27a989a8" />

Storybook: https://681172a4db05900a35c3a4ba-dngdujuubp.chromatic.com/?path=/story/pages-ucsbdiningcommonsmenuitem-ucsbdiningcommonsmenuitemeditpage--default