### PR TITLE
Kade - Create Page for UCSBOrganization plus tests and stories

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -132,7 +132,7 @@ function App() {
             />
           </>
         )}
-        
+
         {hasRole(currentUser, "ROLE_USER") && (
           <>
             <Route

--- a/frontend/src/main/pages/UCSBOrganization/UCSBOrganizationCreatePage.js
+++ b/frontend/src/main/pages/UCSBOrganization/UCSBOrganizationCreatePage.js
@@ -1,11 +1,50 @@
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import OrganizationForm from "main/components/Organizations/OrganizationForm";
+import { Navigate } from "react-router-dom";
+import { useBackendMutation } from "main/utils/useBackend";
+import { toast } from "react-toastify";
 
-export default function UCSBOrganizationCreatePage() {
-  // Stryker disable all : placeholder for future implementation
+export default function UCSBOrganizationCreatePage({ storybook = false }) {
+  const objectToAxiosParams = (organization) => ({
+    url: "/api/ucsborganization/post",
+    method: "POST",
+    params: {
+      orgCode: organization.orgCode,
+      orgTranslationShort: organization.orgTranslationShort,
+      orgTranslation: organization.orgTranslation,
+      inactive: organization.inactive,
+    },
+  });
+
+  const onSuccess = (organization) => {
+    toast(
+      `New organization Created - orgCode: ${organization.orgCode} orgTranslationShort: ${organization.orgTranslationShort} orgTranslation: ${organization.orgTranslation} inactive: ${organization.inactive}`,
+    );
+  };
+
+  const mutation = useBackendMutation(
+    objectToAxiosParams,
+    { onSuccess },
+    // Stryker disable next-line all : hard to set up test for caching
+    ["/api/ucsborganization/all"], // mutation makes this key stale so that pages relying on it reload
+  );
+
+  const { isSuccess } = mutation;
+
+  const onSubmit = async (data) => {
+    data.inactive = data.inactive === "true" ? true : false;
+    mutation.mutate(data);
+  };
+
+  if (isSuccess && !storybook) {
+    return <Navigate to="/ucsborganization" />;
+  }
+
   return (
     <BasicLayout>
       <div className="pt-2">
-        <h1>Create page not yet implemented</h1>
+        <h1>Create New Organization</h1>
+        <OrganizationForm submitAction={onSubmit} />
       </div>
     </BasicLayout>
   );

--- a/frontend/src/stories/pages/UCSBOrganization/UCSBOrganizationCreatePage.stories.js
+++ b/frontend/src/stories/pages/UCSBOrganization/UCSBOrganizationCreatePage.stories.js
@@ -1,0 +1,32 @@
+import React from "react";
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import { http, HttpResponse } from "msw";
+
+import UCSBOrganizationCreatePage from "main/pages/UCSBOrganization/UCSBOrganizationCreatePage";
+
+export default {
+  title: "pages/UCSBOrganization/UCSBOrganizationCreatePage",
+  component: UCSBOrganizationCreatePage,
+};
+
+const Template = () => <UCSBOrganizationCreatePage storybook={true} />;
+
+export const Default = Template.bind({});
+Default.parameters = {
+  msw: [
+    http.get("/api/currentUser", () => {
+      return HttpResponse.json(apiCurrentUserFixtures.userOnly, {
+        status: 200,
+      });
+    }),
+    http.get("/api/systemInfo", () => {
+      return HttpResponse.json(systemInfoFixtures.showingNeither, {
+        status: 200,
+      });
+    }),
+    http.post("/api/ucsborganization/post", () => {
+      return HttpResponse.json({}, { status: 200 });
+    }),
+  ],
+};

--- a/frontend/src/tests/pages/UCSBOrganization/UCSBOrganizationCreatePage.test.js
+++ b/frontend/src/tests/pages/UCSBOrganization/UCSBOrganizationCreatePage.test.js
@@ -1,17 +1,42 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import UCSBOrganizationCreatePage from "main/pages/UCSBOrganization/UCSBOrganizationCreatePage";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
 
 import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
 
-describe("UCSBOrganizationCreatePage tests", () => {
+const mockToast = jest.fn();
+jest.mock("react-toastify", () => {
+  const originalModule = jest.requireActual("react-toastify");
+  return {
+    __esModule: true,
+    ...originalModule,
+    toast: (x) => mockToast(x),
+  };
+});
+
+const mockNavigate = jest.fn();
+jest.mock("react-router-dom", () => {
+  const originalModule = jest.requireActual("react-router-dom");
+  return {
+    __esModule: true,
+    ...originalModule,
+    Navigate: (x) => {
+      mockNavigate(x);
+      return null;
+    },
+  };
+});
+
+describe("OrganizationCreatePage tests", () => {
   const axiosMock = new AxiosMockAdapter(axios);
 
-  const setupUserOnly = () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
     axiosMock.reset();
     axiosMock.resetHistory();
     axiosMock
@@ -20,15 +45,10 @@ describe("UCSBOrganizationCreatePage tests", () => {
     axiosMock
       .onGet("/api/systemInfo")
       .reply(200, systemInfoFixtures.showingNeither);
-  };
+  });
 
   const queryClient = new QueryClient();
-  test("Renders expected content", async () => {
-    // arrange
-
-    setupUserOnly();
-
-    // act
+  test("renders without crashing", async () => {
     render(
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>
@@ -37,8 +57,130 @@ describe("UCSBOrganizationCreatePage tests", () => {
       </QueryClientProvider>,
     );
 
-    // assert
+    await waitFor(() => {
+      expect(screen.getByLabelText("Organization ID")).toBeInTheDocument();
+    });
+  });
 
-    await screen.findByText("Create page not yet implemented");
+  test("on submit, makes request to backend, and redirects to /ucsborganization where inactive = true", async () => {
+    const queryClient = new QueryClient();
+    const organization = {
+      orgCode: "IEEE",
+      orgTranslationShort: "Engineering",
+      orgTranslation: "Institute of Electrical and Electronics Engineers",
+      inactive: true,
+    };
+
+    axiosMock.onPost("/api/ucsborganization/post").reply(202, organization);
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <UCSBOrganizationCreatePage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("Organization ID")).toBeInTheDocument();
+    });
+
+    const orgCodeInput = screen.getByLabelText("Organization ID");
+    expect(orgCodeInput).toBeInTheDocument();
+
+    const orgTranslationShortInput = screen.getByLabelText("Organization Translation Short");
+    expect(orgTranslationShortInput).toBeInTheDocument();
+
+    const orgTranslationInput = screen.getByLabelText("Organization Translation");
+    expect(orgTranslationInput).toBeInTheDocument();
+
+    const inactiveInput = screen.getByLabelText("Inactive");
+    expect(inactiveInput).toBeInTheDocument();
+
+    const createButton = screen.getByText("Create");
+    expect(createButton).toBeInTheDocument();
+
+    fireEvent.change(orgCodeInput, { target: { value: "IEEE" } });
+    fireEvent.change(orgTranslationShortInput, { target: { value: "Engineering" } });
+    fireEvent.change(orgTranslationInput, { target: { value: "Institute of Electrical and Electronics Engineers" } });
+    fireEvent.change(inactiveInput, { target: { value: true } });
+
+    fireEvent.click(createButton);
+
+    await waitFor(() => expect(axiosMock.history.post.length).toBe(1));
+
+    expect(axiosMock.history.post[0].params).toEqual({
+      orgCode: "IEEE",
+      orgTranslationShort: "Engineering",
+      orgTranslation: "Institute of Electrical and Electronics Engineers",
+      inactive: true,
+    });
+
+    // assert - check that the toast was called with the expected message
+    expect(mockToast).toBeCalledWith(
+      "New organization Created - orgCode: IEEE orgTranslationShort: Engineering orgTranslation: Institute of Electrical and Electronics Engineers inactive: true",
+    );
+    expect(mockNavigate).toBeCalledWith({ to: "/ucsborganization" });
+  });
+
+  test("on submit, makes request to backend, and redirects to /ucsborganization where inactive = false", async () => {
+    const queryClient = new QueryClient();
+    const organization = {
+      orgCode: "IEEE",
+      orgTranslationShort: "Engineering",
+      orgTranslation: "Institute of Electrical and Electronics Engineers",
+      inactive: false,
+    };
+
+    axiosMock.onPost("/api/ucsborganization/post").reply(202, organization);
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <UCSBOrganizationCreatePage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("Organization ID")).toBeInTheDocument();
+    });
+
+    const orgCodeInput = screen.getByLabelText("Organization ID");
+    expect(orgCodeInput).toBeInTheDocument();
+
+    const orgTranslationShortInput = screen.getByLabelText("Organization Translation Short");
+    expect(orgTranslationShortInput).toBeInTheDocument();
+
+    const orgTranslationInput = screen.getByLabelText("Organization Translation");
+    expect(orgTranslationInput).toBeInTheDocument();
+
+    const inactiveInput = screen.getByLabelText("Inactive");
+    expect(inactiveInput).toBeInTheDocument();
+
+    const createButton = screen.getByText("Create");
+    expect(createButton).toBeInTheDocument();
+
+    fireEvent.change(orgCodeInput, { target: { value: "IEEE" } });
+    fireEvent.change(orgTranslationShortInput, { target: { value: "Engineering" } });
+    fireEvent.change(orgTranslationInput, { target: { value: "Institute of Electrical and Electronics Engineers" } });
+    fireEvent.change(inactiveInput, { target: { value: false } });
+
+    fireEvent.click(createButton);
+
+    await waitFor(() => expect(axiosMock.history.post.length).toBe(1));
+
+    expect(axiosMock.history.post[0].params).toEqual({
+      orgCode: "IEEE",
+      orgTranslationShort: "Engineering",
+      orgTranslation: "Institute of Electrical and Electronics Engineers",
+      inactive: false,
+    });
+
+    // assert - check that the toast was called with the expected message
+    expect(mockToast).toBeCalledWith(
+      "New organization Created - orgCode: IEEE orgTranslationShort: Engineering orgTranslation: Institute of Electrical and Electronics Engineers inactive: false",
+    );
+    expect(mockNavigate).toBeCalledWith({ to: "/ucsborganization" });
   });
 });

--- a/frontend/src/tests/pages/UCSBOrganization/UCSBOrganizationCreatePage.test.js
+++ b/frontend/src/tests/pages/UCSBOrganization/UCSBOrganizationCreatePage.test.js
@@ -88,10 +88,14 @@ describe("OrganizationCreatePage tests", () => {
     const orgCodeInput = screen.getByLabelText("Organization ID");
     expect(orgCodeInput).toBeInTheDocument();
 
-    const orgTranslationShortInput = screen.getByLabelText("Organization Translation Short");
+    const orgTranslationShortInput = screen.getByLabelText(
+      "Organization Translation Short",
+    );
     expect(orgTranslationShortInput).toBeInTheDocument();
 
-    const orgTranslationInput = screen.getByLabelText("Organization Translation");
+    const orgTranslationInput = screen.getByLabelText(
+      "Organization Translation",
+    );
     expect(orgTranslationInput).toBeInTheDocument();
 
     const inactiveInput = screen.getByLabelText("Inactive");
@@ -101,8 +105,12 @@ describe("OrganizationCreatePage tests", () => {
     expect(createButton).toBeInTheDocument();
 
     fireEvent.change(orgCodeInput, { target: { value: "IEEE" } });
-    fireEvent.change(orgTranslationShortInput, { target: { value: "Engineering" } });
-    fireEvent.change(orgTranslationInput, { target: { value: "Institute of Electrical and Electronics Engineers" } });
+    fireEvent.change(orgTranslationShortInput, {
+      target: { value: "Engineering" },
+    });
+    fireEvent.change(orgTranslationInput, {
+      target: { value: "Institute of Electrical and Electronics Engineers" },
+    });
     fireEvent.change(inactiveInput, { target: { value: true } });
 
     fireEvent.click(createButton);
@@ -149,10 +157,14 @@ describe("OrganizationCreatePage tests", () => {
     const orgCodeInput = screen.getByLabelText("Organization ID");
     expect(orgCodeInput).toBeInTheDocument();
 
-    const orgTranslationShortInput = screen.getByLabelText("Organization Translation Short");
+    const orgTranslationShortInput = screen.getByLabelText(
+      "Organization Translation Short",
+    );
     expect(orgTranslationShortInput).toBeInTheDocument();
 
-    const orgTranslationInput = screen.getByLabelText("Organization Translation");
+    const orgTranslationInput = screen.getByLabelText(
+      "Organization Translation",
+    );
     expect(orgTranslationInput).toBeInTheDocument();
 
     const inactiveInput = screen.getByLabelText("Inactive");
@@ -162,8 +174,12 @@ describe("OrganizationCreatePage tests", () => {
     expect(createButton).toBeInTheDocument();
 
     fireEvent.change(orgCodeInput, { target: { value: "IEEE" } });
-    fireEvent.change(orgTranslationShortInput, { target: { value: "Engineering" } });
-    fireEvent.change(orgTranslationInput, { target: { value: "Institute of Electrical and Electronics Engineers" } });
+    fireEvent.change(orgTranslationShortInput, {
+      target: { value: "Engineering" },
+    });
+    fireEvent.change(orgTranslationInput, {
+      target: { value: "Institute of Electrical and Electronics Engineers" },
+    });
     fireEvent.change(inactiveInput, { target: { value: false } });
 
     fireEvent.click(createButton);


### PR DESCRIPTION
Merge after #102 
Closes #22 

This PR has : Created Page for UCSBOrganization and replaced Placeholder page, tests for that page and stories for that page


# To Test:
1 log in to this dokku instance 
2 navigate to create page for organization
3 click create
4 check the /api/ucsborganization/all enpoint with swagger to see if the new entry is present
<img width="1119" alt="Screenshot 2025-05-06 at 15 45 32" src="https://github.com/user-attachments/assets/f9daabe5-98c5-4e09-9a2c-59d9dd23a1d2" />
<img width="1248" alt="Screenshot 2025-05-06 at 15 45 59" src="https://github.com/user-attachments/assets/fa88fa58-52af-4264-ac18-f5e9076e0e35" />
<img width="1291" alt="Screenshot 2025-05-06 at 15 46 41" src="https://github.com/user-attachments/assets/09244269-16f2-4ec1-9909-dce61c107c97" />

Storybook link: [chromatic sb](https://ucsb-cs156-s25.github.io/team02-s25-03/prs/103/chromatic) 