### PR TITLE
Il menu item review edit page

### DIFF
--- a/frontend/src/main/pages/MenuItemReview/MenuItemReviewEditPage.js
+++ b/frontend/src/main/pages/MenuItemReview/MenuItemReviewEditPage.js
@@ -36,12 +36,14 @@ export default function MenuItemReviewEditPage({ storybook = false }) {
       reviewerEmail: menuItemReview.reviewerEmail,
       stars: menuItemReview.stars,
       dateReviewed: menuItemReview.dateReviewed,
-      comments: menuItemReview.comments
+      comments: menuItemReview.comments,
     },
   });
 
   const onSuccess = (menuItemReview) => {
-    toast(`Menu Item Review Updated - id: ${menuItemReview.id} reviewerEmail: ${menuItemReview.reviewerEmail} comments: ${menuItemReview.comments}`);
+    toast(
+      `Menu Item Review Updated - id: ${menuItemReview.id} reviewerEmail: ${menuItemReview.reviewerEmail} comments: ${menuItemReview.comments}`,
+    );
   };
 
   const mutation = useBackendMutation(

--- a/frontend/src/main/pages/MenuItemReview/MenuItemReviewEditPage.js
+++ b/frontend/src/main/pages/MenuItemReview/MenuItemReviewEditPage.js
@@ -1,11 +1,77 @@
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import { useParams } from "react-router-dom";
+import MenuItemReviewForm from "main/components/MenuItemReview/MenuItemReviewForm";
+import { Navigate } from "react-router-dom";
+import { useBackend, useBackendMutation } from "main/utils/useBackend";
+import { toast } from "react-toastify";
 
-export default function MenuItemReviewEditPage() {
-  // Stryker disable all : placeholder for future implementation
+export default function MenuItemReviewEditPage({ storybook = false }) {
+  let { id } = useParams();
+
+  const {
+    data: menuItemReview,
+    _error,
+    _status,
+  } = useBackend(
+    // Stryker disable next-line all : don't test internal caching of React Query
+    [`/api/menuitemreview?id=${id}`],
+    {
+      // Stryker disable next-line all : GET is the default, so mutating this to "" doesn't introduce a bug
+      method: "GET",
+      url: `/api/menuitemreview`,
+      params: {
+        id,
+      },
+    },
+  );
+
+  const objectToAxiosPutParams = (menuItemReview) => ({
+    url: "/api/menuitemreview",
+    method: "PUT",
+    params: {
+      id: menuItemReview.id,
+    },
+    data: {
+      itemId: menuItemReview.itemId,
+      reviewerEmail: menuItemReview.reviewerEmail,
+      stars: menuItemReview.stars,
+      dateReviewed: menuItemReview.dateReviewed,
+      comments: menuItemReview.comments
+    },
+  });
+
+  const onSuccess = (menuItemReview) => {
+    toast(`Menu Item Review Updated - id: ${menuItemReview.id} reviewerEmail: ${menuItemReview.reviewerEmail} comments: ${menuItemReview.comments}`);
+  };
+
+  const mutation = useBackendMutation(
+    objectToAxiosPutParams,
+    { onSuccess },
+    // Stryker disable next-line all : hard to set up test for caching
+    [`/api/menuitemreview?id=${id}`],
+  );
+
+  const { isSuccess } = mutation;
+
+  const onSubmit = async (data) => {
+    mutation.mutate(data);
+  };
+
+  if (isSuccess && !storybook) {
+    return <Navigate to="/menuitemreview" />;
+  }
+
   return (
     <BasicLayout>
       <div className="pt-2">
-        <h1>Edit page not yet implemented</h1>
+        <h1>Edit Menu Item Review</h1>
+        {menuItemReview && (
+          <MenuItemReviewForm
+            submitAction={onSubmit}
+            buttonLabel={"Update"}
+            initialContents={menuItemReview}
+          />
+        )}
       </div>
     </BasicLayout>
   );

--- a/frontend/src/main/pages/MenuItemReview/MenuItemReviewIndexPage.js
+++ b/frontend/src/main/pages/MenuItemReview/MenuItemReviewIndexPage.js
@@ -40,7 +40,10 @@ export default function RestaurantIndexPage() {
       <div className="pt-2">
         {createButton()}
         <h1>Menu Item Reviews</h1>
-        <MenuItemReviewTable menuItemReviews={menuItemReviews} currentUser={currentUser} />
+        <MenuItemReviewTable
+          menuItemReviews={menuItemReviews}
+          currentUser={currentUser}
+        />
       </div>
     </BasicLayout>
   );

--- a/frontend/src/main/pages/MenuItemReview/MenuItemReviewIndexPage.js
+++ b/frontend/src/main/pages/MenuItemReview/MenuItemReviewIndexPage.js
@@ -29,7 +29,7 @@ export default function RestaurantIndexPage() {
           href="/menuitemreview/create"
           style={{ float: "right" }}
         >
-          Create Restaurant
+          Create Menu Item Review
         </Button>
       );
     }
@@ -39,7 +39,7 @@ export default function RestaurantIndexPage() {
     <BasicLayout>
       <div className="pt-2">
         {createButton()}
-        <h1>Restaurants</h1>
+        <h1>Menu Item Reviews</h1>
         <MenuItemReviewTable menuItemReviews={menuItemReviews} currentUser={currentUser} />
       </div>
     </BasicLayout>

--- a/frontend/src/main/pages/MenuItemReview/MenuItemReviewIndexPage.js
+++ b/frontend/src/main/pages/MenuItemReview/MenuItemReviewIndexPage.js
@@ -6,7 +6,7 @@ import MenuItemReviewTable from "main/components/MenuItemReview/MenuItemReviewTa
 import { useCurrentUser, hasRole } from "main/utils/currentUser";
 import { Button } from "react-bootstrap";
 
-export default function RestaurantIndexPage() {
+export default function MenuItemReviewIndexPage() {
   const currentUser = useCurrentUser();
 
   const {

--- a/frontend/src/main/pages/MenuItemReview/MenuItemReviewIndexPage.js
+++ b/frontend/src/main/pages/MenuItemReview/MenuItemReviewIndexPage.js
@@ -1,17 +1,46 @@
-import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import React from "react";
+import { useBackend } from "main/utils/useBackend";
 
-export default function MenuItemReviewIndexPage() {
-  // Stryker disable all : placeholder for future implementation
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import MenuItemReviewTable from "main/components/MenuItemReview/MenuItemReviewTable";
+import { useCurrentUser, hasRole } from "main/utils/currentUser";
+import { Button } from "react-bootstrap";
+
+export default function RestaurantIndexPage() {
+  const currentUser = useCurrentUser();
+
+  const {
+    data: menuItemReviews,
+    error: _error,
+    status: _status,
+  } = useBackend(
+    // Stryker disable next-line all : don't test internal caching of React Query
+    ["/api/menuitemreview/all"],
+    { method: "GET", url: "/api/menuitemreview/all" },
+    // Stryker disable next-line all : don't test default value of empty list
+    [],
+  );
+
+  const createButton = () => {
+    if (hasRole(currentUser, "ROLE_ADMIN")) {
+      return (
+        <Button
+          variant="primary"
+          href="/menuitemreview/create"
+          style={{ float: "right" }}
+        >
+          Create Restaurant
+        </Button>
+      );
+    }
+  };
+
   return (
     <BasicLayout>
       <div className="pt-2">
-        <h1>Index page not yet implemented</h1>
-        <p>
-          <a href="/menuitemreview/create">Create</a>
-        </p>
-        <p>
-          <a href="/menuitemreview/edit/1">Edit</a>
-        </p>
+        {createButton()}
+        <h1>Restaurants</h1>
+        <MenuItemReviewTable menuItemReviews={menuItemReviews} currentUser={currentUser} />
       </div>
     </BasicLayout>
   );

--- a/frontend/src/stories/pages/MenuItemReview/MenuItemReviewEditPage.stories.js
+++ b/frontend/src/stories/pages/MenuItemReview/MenuItemReviewEditPage.stories.js
@@ -1,0 +1,52 @@
+import React from "react";
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import { http, HttpResponse } from "msw";
+
+import MenuItemReviewEditPage from "main/pages/MenuItemReview/MenuItemReviewEditPage";
+import { menuItemReviewFixtures } from "fixtures/menuItemReviewFixtures";
+
+export default {
+  title: "pages/MenuItemReview/MenuItemReviewEditPage",
+  component: MenuItemReviewEditPage,
+};
+
+const Template = () => <MenuItemReviewEditPage storybook={true} />;
+
+export const Default = Template.bind({});
+Default.parameters = {
+  msw: [
+    http.get("/api/currentUser", () => {
+      return HttpResponse.json(apiCurrentUserFixtures.userOnly, {
+        status: 200,
+      });
+    }),
+    http.get("/api/systemInfo", () => {
+      return HttpResponse.json(systemInfoFixtures.showingNeither, {
+        status: 200,
+      });
+    }),
+    http.get("/api/menuitemreview", () => {
+      return HttpResponse.json(menuItemReviewFixtures.threeMenuItemReviews[0], {
+        status: 200,
+      });
+    }),
+    // http.put("/api/menuitemreview", () => {
+    //   return HttpResponse.json({}, { status: 200 });
+    // }),
+    http.put("/api/menuitemreview", (/*req*/) => {
+      // window.alert("PUT: " + req.url + " and body: " + req.body);
+      return HttpResponse.json(
+        {
+          id: 17,
+          itemId: 4,
+          reviewerEmail: "cgaucho@ucsb.edua",
+          stars: 2,
+          dateReviewed: "2022-10-30T00:00:02",
+          comments: "edible I guess",
+        },
+        { status: 200 },
+      );
+    }),
+  ],
+};

--- a/frontend/src/stories/pages/MenuItemReview/MenuItemReviewIndexPage.stories.js
+++ b/frontend/src/stories/pages/MenuItemReview/MenuItemReviewIndexPage.stories.js
@@ -1,0 +1,71 @@
+import React from "react";
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import { menuItemReviewFixtures } from "fixtures/menuItemReviewFixtures";
+import { http, HttpResponse } from "msw";
+
+import MenuItemReviewIndexPage from "main/pages/MenuItemReview/MenuItemReviewIndexPage";
+
+export default {
+  title: "pages/MenuItemReview/MenuItemReviewIndexPage",
+  component: MenuItemReviewIndexPage,
+};
+
+const Template = () => <MenuItemReviewIndexPage storybook={true} />;
+
+export const Empty = Template.bind({});
+Empty.parameters = {
+  msw: [
+    http.get("/api/currentUser", () => {
+      return HttpResponse.json(apiCurrentUserFixtures.userOnly, {
+        status: 200,
+      });
+    }),
+    http.get("/api/systemInfo", () => {
+      return HttpResponse.json(systemInfoFixtures.showingNeither, {
+        status: 200,
+      });
+    }),
+    http.get("/api/menuitemreview/all", () => {
+      return HttpResponse.json([], { status: 200 });
+    }),
+  ],
+};
+
+export const ThreeItemsOrdinaryUser = Template.bind({});
+
+ThreeItemsOrdinaryUser.parameters = {
+  msw: [
+    http.get("/api/currentUser", () => {
+      return HttpResponse.json(apiCurrentUserFixtures.userOnly);
+    }),
+    http.get("/api/systemInfo", () => {
+      return HttpResponse.json(systemInfoFixtures.showingNeither);
+    }),
+    http.get("/api/menuitemreview/all", () => {
+      return HttpResponse.json(menuItemReviewFixtures.threeMenuItemReviews);
+    }),
+  ],
+};
+
+export const ThreeItemsAdminUser = Template.bind({});
+
+ThreeItemsAdminUser.parameters = {
+  msw: [
+    http.get("/api/currentUser", () => {
+      return HttpResponse.json(apiCurrentUserFixtures.adminUser);
+    }),
+    http.get("/api/systemInfo", () => {
+      return HttpResponse.json(systemInfoFixtures.showingNeither);
+    }),
+    http.get("/api/menuitemreview/all", () => {
+      return HttpResponse.json(menuItemReviewFixtures.threeMenuItemReviews);
+    }),
+    http.delete("/api/menuitemreview", () => {
+      return HttpResponse.json(
+        { message: "Menu Item Review deleted successfully" },
+        { status: 200 },
+      );
+    }),
+  ],
+};

--- a/frontend/src/tests/pages/MenuItemReview/MenuItemReviewEditPage.test.js
+++ b/frontend/src/tests/pages/MenuItemReview/MenuItemReviewEditPage.test.js
@@ -100,7 +100,7 @@ describe("MenuItemReviewEditPage tests", () => {
 
     const queryClient = new QueryClient();
 
-    test.only("Is populated with the data provided", async () => {
+    test("Is populated with the data provided, and changes when data is changed", async () => {
       render(
         <QueryClientProvider client={queryClient}>
           <MemoryRouter>
@@ -152,14 +152,14 @@ describe("MenuItemReviewEditPage tests", () => {
       fireEvent.change(dateReviewedField, {
         target: { value: "2022-10-30T00:00:02" },
       });
-      fireEvent.change(itemIdField, {
+      fireEvent.change(commentsField, {
         target: { value: "edible I guess" },
       });
       fireEvent.click(submitButton);
 
       await waitFor(() => expect(mockToast).toHaveBeenCalled());
       expect(mockToast).toHaveBeenCalledWith(
-        "Menu Item Review Updated - id: 17 reviewerEmail: cgaucho@ucsb.edu comments: bland af but edible I guess",
+        "Menu Item Review Updated - id: 17 reviewerEmail: cgaucho@ucsb.edua comments: edible I guess",
       );
 
       expect(mockNavigate).toHaveBeenCalledWith({ to: "/menuitemreview" });
@@ -168,48 +168,15 @@ describe("MenuItemReviewEditPage tests", () => {
       expect(axiosMock.history.put[0].params).toEqual({ id: 17 });
       expect(axiosMock.history.put[0].data).toBe(
         JSON.stringify({
-          itemId: 4,
+          itemId: "4",
           reviewerEmail: "cgaucho@ucsb.edua",
-          stars: 2,
+          stars: "2",
           dateReviewed: "2022-10-30T00:00:02.000",
           comments: "edible I guess",
         }),
       ); // posted object
-    });
 
-    test("Changes when you click Update", async () => {
-      render(
-        <QueryClientProvider client={queryClient}>
-          <MemoryRouter>
-            <MenuItemReviewEditPage />
-          </MemoryRouter>
-        </QueryClientProvider>,
-      );
-
-      await screen.findByTestId("MenuItemReviewForm-id");
-
-      const idField = screen.getByTestId("MenuItemReviewForm-id");
-      const nameField = screen.getByTestId("MenuItemReviewForm-name");
-      const descriptionField = screen.getByTestId("MenuItemReviewForm-description");
-      const submitButton = screen.getByTestId("MenuItemReviewForm-submit");
-
-      expect(idField).toHaveValue("17");
-      expect(nameField).toHaveValue("Freebirds");
-      expect(descriptionField).toHaveValue("Burritos");
-      expect(submitButton).toBeInTheDocument();
-
-      fireEvent.change(nameField, {
-        target: { value: "Freebirds World Burrito" },
-      });
-      fireEvent.change(descriptionField, { target: { value: "Big Burritos" } });
-
-      fireEvent.click(submitButton);
-
-      await waitFor(() => expect(mockToast).toBeCalled());
-      expect(mockToast).toHaveBeenCalledWith(
-        "Restaurant Updated - id: 17 name: Freebirds World Burrito",
-      );
       expect(mockNavigate).toHaveBeenCalledWith({ to: "/menuitemreview" });
-    });
+    });    
   });
 });

--- a/frontend/src/tests/pages/MenuItemReview/MenuItemReviewEditPage.test.js
+++ b/frontend/src/tests/pages/MenuItemReview/MenuItemReviewEditPage.test.js
@@ -63,7 +63,9 @@ describe("MenuItemReviewEditPage tests", () => {
         </QueryClientProvider>,
       );
       await screen.findByText("Edit Menu Item Review");
-      expect(screen.queryByTestId("MenuItemReview-reviewerEmail")).not.toBeInTheDocument();
+      expect(
+        screen.queryByTestId("MenuItemReview-reviewerEmail"),
+      ).not.toBeInTheDocument();
       restoreConsole();
     });
   });
@@ -80,16 +82,18 @@ describe("MenuItemReviewEditPage tests", () => {
       axiosMock
         .onGet("/api/systemInfo")
         .reply(200, systemInfoFixtures.showingNeither);
-      axiosMock.onGet("/api/menuitemreview", { params: { id: 17 } }).reply(200, {
-        id: 17,        
-        itemId: 27,
-        reviewerEmail: "cgaucho@ucsb.edu",
-        stars: 3,
-        dateReviewed: "2022-04-20T00:00:01",
-        comments: "bland af but edible I guess",
-      });
+      axiosMock
+        .onGet("/api/menuitemreview", { params: { id: 17 } })
+        .reply(200, {
+          id: 17,
+          itemId: 27,
+          reviewerEmail: "cgaucho@ucsb.edu",
+          stars: 3,
+          dateReviewed: "2022-04-20T00:00:01",
+          comments: "bland af but edible I guess",
+        });
       axiosMock.onPut("/api/menuitemreview").reply(200, {
-        id: 17,        
+        id: 17,
         itemId: 4,
         reviewerEmail: "cgaucho@ucsb.edua",
         stars: 2,
@@ -115,7 +119,9 @@ describe("MenuItemReviewEditPage tests", () => {
       const itemIdField = screen.getByLabelText("Item ID");
       const reviewerEmailField = screen.getByLabelText("Reviewer Email");
       const starsField = screen.getByLabelText("Stars");
-      const dateReviewedField = screen.getByLabelText("Date Reviewed (iso format)");
+      const dateReviewedField = screen.getByLabelText(
+        "Date Reviewed (iso format)",
+      );
       const commentsField = screen.getByLabelText("Comments");
 
       const submitButton = screen.getByText("Update");
@@ -177,6 +183,6 @@ describe("MenuItemReviewEditPage tests", () => {
       ); // posted object
 
       expect(mockNavigate).toHaveBeenCalledWith({ to: "/menuitemreview" });
-    });    
+    });
   });
 });

--- a/frontend/src/tests/pages/MenuItemReview/MenuItemReviewEditPage.test.js
+++ b/frontend/src/tests/pages/MenuItemReview/MenuItemReviewEditPage.test.js
@@ -1,43 +1,215 @@
-import { render, screen } from "@testing-library/react";
-import MenuItemReviewEditPage from "main/pages/MenuItemReview/MenuItemReviewEditPage";
+import { fireEvent, render, waitFor, screen } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
+import MenuItemReviewEditPage from "main/pages/MenuItemReview/MenuItemReviewEditPage";
 
 import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
+import mockConsole from "jest-mock-console";
+
+const mockToast = jest.fn();
+jest.mock("react-toastify", () => {
+  const originalModule = jest.requireActual("react-toastify");
+  return {
+    __esModule: true,
+    ...originalModule,
+    toast: (x) => mockToast(x),
+  };
+});
+
+const mockNavigate = jest.fn();
+jest.mock("react-router-dom", () => {
+  const originalModule = jest.requireActual("react-router-dom");
+  return {
+    __esModule: true,
+    ...originalModule,
+    useParams: () => ({
+      id: 17,
+    }),
+    Navigate: (x) => {
+      mockNavigate(x);
+      return null;
+    },
+  };
+});
 
 describe("MenuItemReviewEditPage tests", () => {
-  const axiosMock = new AxiosMockAdapter(axios);
+  describe("when the backend doesn't return data", () => {
+    const axiosMock = new AxiosMockAdapter(axios);
 
-  const setupUserOnly = () => {
-    axiosMock.reset();
-    axiosMock.resetHistory();
-    axiosMock
-      .onGet("/api/currentUser")
-      .reply(200, apiCurrentUserFixtures.userOnly);
-    axiosMock
-      .onGet("/api/systemInfo")
-      .reply(200, systemInfoFixtures.showingNeither);
-  };
+    beforeEach(() => {
+      axiosMock.reset();
+      axiosMock.resetHistory();
+      axiosMock
+        .onGet("/api/currentUser")
+        .reply(200, apiCurrentUserFixtures.userOnly);
+      axiosMock
+        .onGet("/api/systemInfo")
+        .reply(200, systemInfoFixtures.showingNeither);
+      axiosMock.onGet("/api/menuitemreview", { params: { id: 17 } }).timeout();
+    });
 
-  const queryClient = new QueryClient();
-  test("Renders expected content", async () => {
-    // arrange
+    const queryClient = new QueryClient();
+    test("renders header but form is not present", async () => {
+      const restoreConsole = mockConsole();
 
-    setupUserOnly();
+      render(
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter>
+            <MenuItemReviewEditPage />
+          </MemoryRouter>
+        </QueryClientProvider>,
+      );
+      await screen.findByText("Edit Menu Item Review");
+      expect(screen.queryByTestId("MenuItemReview-reviewerEmail")).not.toBeInTheDocument();
+      restoreConsole();
+    });
+  });
 
-    // act
-    render(
-      <QueryClientProvider client={queryClient}>
-        <MemoryRouter>
-          <MenuItemReviewEditPage />
-        </MemoryRouter>
-      </QueryClientProvider>,
-    );
+  describe("tests where backend is working normally", () => {
+    const axiosMock = new AxiosMockAdapter(axios);
 
-    // assert
-    await screen.findByText("Edit page not yet implemented");
+    beforeEach(() => {
+      axiosMock.reset();
+      axiosMock.resetHistory();
+      axiosMock
+        .onGet("/api/currentUser")
+        .reply(200, apiCurrentUserFixtures.userOnly);
+      axiosMock
+        .onGet("/api/systemInfo")
+        .reply(200, systemInfoFixtures.showingNeither);
+      axiosMock.onGet("/api/menuitemreview", { params: { id: 17 } }).reply(200, {
+        id: 17,        
+        itemId: 27,
+        reviewerEmail: "cgaucho@ucsb.edu",
+        stars: 3,
+        dateReviewed: "2022-04-20T00:00:01",
+        comments: "bland af but edible I guess",
+      });
+      axiosMock.onPut("/api/menuitemreview").reply(200, {
+        id: 17,        
+        itemId: 4,
+        reviewerEmail: "cgaucho@ucsb.edua",
+        stars: 2,
+        dateReviewed: "2022-10-30T00:00:02",
+        comments: "edible I guess",
+      });
+    });
+
+    const queryClient = new QueryClient();
+
+    test.only("Is populated with the data provided", async () => {
+      render(
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter>
+            <MenuItemReviewEditPage />
+          </MemoryRouter>
+        </QueryClientProvider>,
+      );
+
+      await screen.findByTestId("MenuItemReviewForm-id");
+
+      const idField = screen.getByLabelText("Id");
+      const itemIdField = screen.getByLabelText("Item ID");
+      const reviewerEmailField = screen.getByLabelText("Reviewer Email");
+      const starsField = screen.getByLabelText("Stars");
+      const dateReviewedField = screen.getByLabelText("Date Reviewed (iso format)");
+      const commentsField = screen.getByLabelText("Comments");
+
+      const submitButton = screen.getByText("Update");
+
+      expect(idField).toBeInTheDocument();
+      expect(idField).toHaveValue("17");
+
+      expect(itemIdField).toBeInTheDocument();
+      expect(itemIdField).toHaveValue(27);
+
+      expect(reviewerEmailField).toBeInTheDocument();
+      expect(reviewerEmailField).toHaveValue("cgaucho@ucsb.edu");
+
+      expect(starsField).toBeInTheDocument();
+      expect(starsField).toHaveValue(3);
+
+      expect(dateReviewedField).toBeInTheDocument();
+      expect(dateReviewedField).toHaveValue("2022-04-20T00:00:01.000");
+
+      expect(commentsField).toBeInTheDocument();
+      expect(commentsField).toHaveValue("bland af but edible I guess");
+
+      expect(submitButton).toHaveTextContent("Update");
+
+      fireEvent.change(itemIdField, {
+        target: { value: 4 },
+      });
+      fireEvent.change(reviewerEmailField, {
+        target: { value: "cgaucho@ucsb.edua" },
+      });
+      fireEvent.change(starsField, {
+        target: { value: 2 },
+      });
+      fireEvent.change(dateReviewedField, {
+        target: { value: "2022-10-30T00:00:02" },
+      });
+      fireEvent.change(itemIdField, {
+        target: { value: "edible I guess" },
+      });
+      fireEvent.click(submitButton);
+
+      await waitFor(() => expect(mockToast).toHaveBeenCalled());
+      expect(mockToast).toHaveBeenCalledWith(
+        "Menu Item Review Updated - id: 17 reviewerEmail: cgaucho@ucsb.edu comments: bland af but edible I guess",
+      );
+
+      expect(mockNavigate).toHaveBeenCalledWith({ to: "/menuitemreview" });
+
+      expect(axiosMock.history.put.length).toBe(1); // times called
+      expect(axiosMock.history.put[0].params).toEqual({ id: 17 });
+      expect(axiosMock.history.put[0].data).toBe(
+        JSON.stringify({
+          itemId: 4,
+          reviewerEmail: "cgaucho@ucsb.edua",
+          stars: 2,
+          dateReviewed: "2022-10-30T00:00:02.000",
+          comments: "edible I guess",
+        }),
+      ); // posted object
+    });
+
+    test("Changes when you click Update", async () => {
+      render(
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter>
+            <MenuItemReviewEditPage />
+          </MemoryRouter>
+        </QueryClientProvider>,
+      );
+
+      await screen.findByTestId("MenuItemReviewForm-id");
+
+      const idField = screen.getByTestId("MenuItemReviewForm-id");
+      const nameField = screen.getByTestId("MenuItemReviewForm-name");
+      const descriptionField = screen.getByTestId("MenuItemReviewForm-description");
+      const submitButton = screen.getByTestId("MenuItemReviewForm-submit");
+
+      expect(idField).toHaveValue("17");
+      expect(nameField).toHaveValue("Freebirds");
+      expect(descriptionField).toHaveValue("Burritos");
+      expect(submitButton).toBeInTheDocument();
+
+      fireEvent.change(nameField, {
+        target: { value: "Freebirds World Burrito" },
+      });
+      fireEvent.change(descriptionField, { target: { value: "Big Burritos" } });
+
+      fireEvent.click(submitButton);
+
+      await waitFor(() => expect(mockToast).toBeCalled());
+      expect(mockToast).toHaveBeenCalledWith(
+        "Restaurant Updated - id: 17 name: Freebirds World Burrito",
+      );
+      expect(mockNavigate).toHaveBeenCalledWith({ to: "/menuitemreview" });
+    });
   });
 });

--- a/frontend/src/tests/pages/MenuItemReview/MenuItemReviewIndexPage.test.js
+++ b/frontend/src/tests/pages/MenuItemReview/MenuItemReviewIndexPage.test.js
@@ -1,15 +1,29 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
 import MenuItemReviewIndexPage from "main/pages/MenuItemReview/MenuItemReviewIndexPage";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
+import mockConsole from "jest-mock-console";
+import { menuItemReviewFixtures } from "fixtures/menuItemReviewFixtures";
 
 import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
 
+const mockToast = jest.fn();
+jest.mock("react-toastify", () => {
+  const originalModule = jest.requireActual("react-toastify");
+  return {
+    __esModule: true,
+    ...originalModule,
+    toast: (x) => mockToast(x),
+  };
+});
+
 describe("MenuItemReviewIndexPage tests", () => {
   const axiosMock = new AxiosMockAdapter(axios);
+
+  const testId = "MenuItemReviewTable";
 
   const setupUserOnly = () => {
     axiosMock.reset();
@@ -22,13 +36,22 @@ describe("MenuItemReviewIndexPage tests", () => {
       .reply(200, systemInfoFixtures.showingNeither);
   };
 
+  const setupAdminUser = () => {
+    axiosMock.reset();
+    axiosMock.resetHistory();
+    axiosMock
+      .onGet("/api/currentUser")
+      .reply(200, apiCurrentUserFixtures.adminUser);
+    axiosMock
+      .onGet("/api/systemInfo")
+      .reply(200, systemInfoFixtures.showingNeither);
+  };
+
   const queryClient = new QueryClient();
-  test("Renders expected content", async () => {
-    // arrange
 
-    setupUserOnly();
-
-    // act
+  test("Renders with Create Button for admin user", async () => {
+    setupAdminUser();
+    axiosMock.onGet("/api/menuitemreview/all").reply(200, []);
 
     render(
       <QueryClientProvider client={queryClient}>
@@ -38,13 +61,129 @@ describe("MenuItemReviewIndexPage tests", () => {
       </QueryClientProvider>,
     );
 
-    await screen.findByText("Index page not yet implemented");
+    await waitFor(() => {
+      expect(screen.getByText(/Create Menu Item Review/)).toBeInTheDocument();
+    });
+    const button = screen.getByText(/Create Menu Item Review/);
+    expect(button).toHaveAttribute("href", "/menuitemreview/create");
+    expect(button).toHaveAttribute("style", "float: right;");
+  });
 
-    // assert
+  test("renders three menu item reviews correctly for regular user", async () => {
+    setupUserOnly();
+    axiosMock
+      .onGet("/api/menuitemreview/all")
+      .reply(200, menuItemReviewFixtures.threeMenuItemReviews);
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <MenuItemReviewIndexPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId(`${testId}-cell-row-0-col-id`),
+      ).toHaveTextContent("1");
+    });
+    expect(screen.getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent(
+      "2",
+    );
+    expect(screen.getByTestId(`${testId}-cell-row-2-col-id`)).toHaveTextContent(
+      "3",
+    );
+
+    const createButton = screen.queryByText("Create Menu Item Review");
+    expect(createButton).not.toBeInTheDocument();
+
+    const itemId = screen.getByText("27");
+    expect(itemId).toBeInTheDocument();
+
+    const comments = screen.getByText("bland af but edible I guess");
+    expect(comments).toBeInTheDocument();
+
+    // for non-admin users, details button is visible, but the edit and delete buttons should not be visible
     expect(
-      screen.getByText("Index page not yet implemented"),
-    ).toBeInTheDocument();
-    expect(screen.getByText("Create")).toBeInTheDocument();
-    expect(screen.getByText("Edit")).toBeInTheDocument();
+      screen.queryByTestId("RestaurantTable-cell-row-0-col-Delete-button"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId("RestaurantTable-cell-row-0-col-Edit-button"),
+    ).not.toBeInTheDocument();
+  });
+
+  test("renders empty table when backend unavailable, user only", async () => {
+    setupUserOnly();
+
+    axiosMock.onGet("/api/menuitemreview/all").timeout();
+
+    const restoreConsole = mockConsole();
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <MenuItemReviewIndexPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(axiosMock.history.get.length).toBeGreaterThanOrEqual(1);
+    });
+
+    const errorMessage = console.error.mock.calls[0][0];
+    expect(errorMessage).toMatch(
+      "Error communicating with backend via GET on /api/menuitemreview/all",
+    );
+    restoreConsole();
+  });
+
+  test("what happens when you click delete, admin", async () => {
+    setupAdminUser();
+
+    axiosMock
+      .onGet("/api/menuitemreview/all")
+      .reply(200, menuItemReviewFixtures.threeMenuItemReviews);
+    axiosMock
+      .onDelete("/api/menuitemreview")
+      .reply(200, "Menu Item Review with id 1 was deleted");
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <MenuItemReviewIndexPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId(`${testId}-cell-row-0-col-id`),
+      ).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent(
+      "1",
+    );
+
+    const deleteButton = screen.getByTestId(
+      `${testId}-cell-row-0-col-Delete-button`,
+    );
+    expect(deleteButton).toBeInTheDocument();
+
+    fireEvent.click(deleteButton);
+
+    await waitFor(() => {
+      expect(mockToast).toHaveBeenCalledWith(
+        "Menu Item Review with id 1 was deleted",
+      );
+    });
+
+    await waitFor(() => {
+      expect(axiosMock.history.delete.length).toBe(1);
+    });
+    expect(axiosMock.history.delete[0].url).toBe("/api/menuitemreview");
+    expect(axiosMock.history.delete[0].params).toEqual({ id: 1 });
   });
 });


### PR DESCRIPTION
Closes #42 

In this PR we replace the placeholder MenuItemReview edit page with a working edit page.

To test:

1. Visit the dokku deployment at https://team02-ilandry-ucsb-dev.dokku-03.cs.ucsb.edu/
2. Log in
3. Navigate to the Menu Item Review page. If there isn't a menu item review listed there, create one.
4. Click the edit button
5. Make changes to each of the fields and click Update
6. See that your changes took effect.

Storybook: https://681172a4db05900a35c3a4ba-fsqdoiaath.chromatic.com/?path=/story/pages-menuitemreview-menuitemrevieweditpage--default

Screenshot:

![menu-item-review-edit-page](https://github.com/user-attachments/assets/ecc42cbc-7ad1-40f4-ab36-9ebe41a62872)
